### PR TITLE
Task/SFIO-18408 parse thumbnails from all manifests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ edition = "2021"
 
 [dependencies]
 c2pa = {version="^0.25.2", features=["file_io", "fetch_remote_manifests"]}
+clap = { version = "4.0", features = ["derive"] }
 base64 = "^0.13.1"
 serde = { version = "^1.0.160", features = ["derive"] }
 serde_json = "^1.0.96"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ readme = "README.md"
 repository = "https://github.com/SmartFrame-Technologies/c2pa-thumbs.git"
 keywords = ["c2pa", "thumbnail"]
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ struct Args {
     #[arg(help = "The path to the file to read")]
     path: String,
 
-    #[arg(short, long, help = "The manifest id - if not passed use active manifest")]
+    #[arg(short, long, help = "The manifest label - if not passed, active manifest will be used")]
     manifest_label: Option<String>,
 
     #[arg(short, help = "List manifests labels")]

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> Result<(), Box<dyn Error>> {
 
     for i in 0..ingredients.len() {
         if let Some((format, data)) = ingredients[i].thumbnail() {
-        thumbs.thumbnails.push(format!("data:{};charset=utf-8;base64,{}", format, base64::encode(data.to_vec())));
+            thumbs.thumbnails.push(format!("data:{};charset=utf-8;base64,{}", format, base64::encode(data.to_vec())));
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,10 +1,11 @@
 use c2pa::ManifestStore;
-use std::env;
+use c2pa::Manifest;
 use std::error::Error;
-use std::process;
 use base64;
+use std::process;
 use serde::{Serialize, Deserialize};
 use serde_json;
+use clap::Parser;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct ManifestThumbs {
@@ -12,26 +13,53 @@ struct ManifestThumbs {
     thumbnails: Vec<String>
 }
 
-fn main() -> Result<(), Box<dyn Error>> {
-    let args: Vec<String> = env::args().collect();
+#[derive(Parser)]
+#[command(about = "I'm parsing cai data from images. Use `-h` to see more.", long_about = None)]
+struct Args {
+    #[arg(help = "The path to the file to read")]
+    path: String,
 
-    if args.len() < 2 {
-        println!("Please provide file");
+    #[arg(short, long, help = "The manifest id - if not passed use active manifest")]
+    manifest_label: Option<String>,
+
+    #[arg(short, help = "List manifests labels")]
+    list_manifests_labels: bool,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Args::parse();
+
+    let manifest_store = ManifestStore::from_file(args.path)?;
+
+    if args.list_manifests_labels {
+        println!("Possible manifests: ");
+        for key in manifest_store.manifests().keys() {
+            println!("{key}");
+        }
+        process::exit(0x0000);
+    }
+
+    let manifest: Option<&Manifest>;
+    if args.manifest_label.is_none() {
+        manifest = manifest_store.get_active();
+    } else {
+        manifest = manifest_store.get(args.manifest_label.unwrap().as_str());
+    }
+
+    let mut thumbs = ManifestThumbs { thumbnail: None, thumbnails: Vec::new()};
+    if manifest.is_none() {
+        println!("Error: Manifest unknown");
         process::exit(0x0100);
     }
 
-    let file_path = &args[1];
-    let manifest_store = ManifestStore::from_file(file_path)?;
-    let manifest = manifest_store.get_active().unwrap();
-    let ingredients = manifest.ingredients();
-    let mut thumbs = ManifestThumbs { thumbnail: None, thumbnails: Vec::new()};
-    if let Some((format, data)) = manifest.thumbnail() {
+    let ingredients = manifest.unwrap().ingredients();
+    if let Some((format, data)) = manifest.unwrap().thumbnail() {
         thumbs.thumbnail = Some(format!("data:{};charset=utf-8;base64,{}", format, base64::encode(data.to_vec())));
     }
 
     for i in 0..ingredients.len() {
         if let Some((format, data)) = ingredients[i].thumbnail() {
-            thumbs.thumbnails.push(format!("data:{};charset=utf-8;base64,{}", format, base64::encode(data.to_vec())));
+        thumbs.thumbnails.push(format!("data:{};charset=utf-8;base64,{}", format, base64::encode(data.to_vec())));
         }
     }
 


### PR DESCRIPTION
task/SFIO-18408: parse thumbnails from given manifests:
- option -m to select manifest label
- option -l to list all manifest's label